### PR TITLE
Update for maps API of Naver Business Platform

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -4,8 +4,8 @@
 	<title xml:lang="en">Maps</title>
 	<description xml:lang="ko">지도를 원하는 곳에 추가하거나 수정할 수 있습니다. OpenStreetMap, Google Maps API, 카카오 지도 API, 카카오 로컬 API, 또는 네이버 지도 API 가 사용되었습니다.</description>
 	<description xml:lang="en">Maps can be inserted in your documents. OpenStreetMap, Google Maps API, KAKAO Maps API, KAKAO Local API, or Naver Maps API are included.</description>
-	<version>1.4.4</version>
-	<date>2018-03-01</date>
+	<version>1.4.5</version>
+	<date>2019-06-07</date>
 	<license link="http://www.gnu.org/licenses/gpl-3.0.html">GPLv3</license>
 	<author email_address="misol.kr@gmail.com" link="https://github.com/misol">
 		<name xml:lang="ko">김민수(misol)</name>
@@ -20,22 +20,22 @@
 			아무 값을 입력하지 않을 경우, 오픈스트리트맵이 나타납니다.</description>
 		</var>
 		<var name="soo_daum_local_api_key">
-			<title xml:lang="ko">카카오 REST API 키 (선택적 필수, 카카오 지도를 사용할 경우)</title>
+			<title xml:lang="ko">카카오 REST API 키 (필수, 카카오 지도를 사용할 경우)</title>
 			<title xml:lang="en">Kakao REST API Key (For KAKAO maps)</title>
 			<description>https://developers.kakao.com/apps 에서 앱 만들기 후, API 키 메뉴에서 REST API 키 항목을 통해 웹 브라우저용 API 키를 발급 받으신 키를 입력해주세요.</description>
 		</var>
 		<var name="soo_naver_secret_key">
-			<title xml:lang="ko">Client Secret(선택적 필수, 네이버 지도를 사용할 경우)</title>
+			<title xml:lang="ko">Client Secret(필수, 네이버 지도를 사용할 경우)</title>
 			<title xml:lang="en">Client Secret (For Naver maps)</title>
 			<description>https://developers.naver.com/appinfo 에서 앱 등록 후 Client Secret 키를 발급받은 후 입력해주세요.</description>
 		</var>
 		<var name="soo_map_api_type" type="select">
-			<title xml:lang="ko">지도 API Key 발급자(권장)</title>
-			<title xml:lang="en">Maps API Key Distributors (Recommend)</title>
-			<description xml:lang="ko">API Key 가 사용되는 지도를 사용할 경우 선택해주시는 것이 좋습니다.</description>
+			<title xml:lang="ko">지도 API Key 발급자</title>
+			<title xml:lang="en">Maps API Key Distributors</title>
+			<description xml:lang="ko">API Key 발급자를 선택해주시는 것이 좋습니다.</description>
 			<options value="">
-				<title xml:lang="ko">자동 선택</title>
-				<title xml:lang="en">Auto selection</title>
+				<title xml:lang="ko">자동 선택 (권장하지 않음)</title>
+				<title xml:lang="en">Auto selection (not recommended)</title>
 			</options>
 			<options value="daum">
 				<title xml:lang="ko">카카오</title>

--- a/tpl/leaflet.js
+++ b/tpl/leaflet.js
@@ -1,4 +1,4 @@
-/* Map Component by MinSoo Kim. (c) 2014 MinSoo Kim. (misol.kr@gmail.com) */
+/* Map Component by Min-Soo Kim. (c) 2014 Min-Soo Kim. (misol.kr@gmail.com) */
 var map_zoom = 13,
 	map_lat = '',
 	map_lng = '',

--- a/tpl/naver_map.js
+++ b/tpl/naver_map.js
@@ -1,4 +1,4 @@
-/* Map Component by MinSoo Kim. (c) 2014 MinSoo Kim. (misol.kr@gmail.com) */
+/* Map Component by Min-Soo Kim. (c) 2019 Min-Soo Kim. (misol.kr@gmail.com) */
 var map_zoom = 13,
 	map_lat = '',
 	map_lng = '',
@@ -95,7 +95,7 @@ function address_adder(results) {
 function getMaps() {
 	var node;
 	var mapOption = {
-		zoom: (map_zoom - 5),
+		zoom: (map_zoom - 4),
 		center: new naver.maps.LatLng(defaultlat, defaultlng),
 		mapTypeControl: true,
 		zoomControl: true,
@@ -135,7 +135,7 @@ function getMaps() {
 			map_marker_positions = img_data.map_markers.trim();
 			marker = addMarker(0);
 
-			map_zoom = (parseInt(img_data.map_zoom,10) - 5);
+			map_zoom = (parseInt(img_data.map_zoom,10) - 4);
 			if(!map_zoom) map_zoom = 13;
 			map.setZoom(map_zoom);
 		}, response_tags);
@@ -295,7 +295,7 @@ function insertMap(obj) {
 	if(typeof(opener)=="undefined" || !opener) return;
 	var width = jQuery("#width").val(), height = jQuery("#height").val();
 
-	map_zoom = map.getZoom()+5;
+	map_zoom = map.getZoom()+4;
 	map_lat = map.getCenter().lat();
 	map_lng = map.getCenter().lng();
 	if(!width) {width = '600';}
@@ -319,7 +319,7 @@ function insertMap(obj) {
 		img_data = results;
 
 		
-		var img_url = "https://naveropenapi.apigw.ntruss.com/map-static/v2/raster-cors?w="+width+"&amp;h="+height+"&amp;center="+map_lng+','+map_lat+"&amp;level="+map_zoom+"&amp;X-NCP-APIGW-API-KEY-ID="+encodeURIComponent(soo_map_api);
+		var img_url = "https://naveropenapi.apigw.ntruss.com/map-static/v2/raster-cors?w="+width+"&amp;h="+height+"&amp;center="+map_lng+','+map_lat+"&amp;level="+(map_zoom-1)+"&amp;X-NCP-APIGW-API-KEY-ID="+encodeURIComponent(soo_map_api);
 		
 		var positions = map_marker_positions.split(";");
 		for(var i = 0; i < positions.length; i++)

--- a/tpl/naver_map.js
+++ b/tpl/naver_map.js
@@ -318,15 +318,23 @@ function insertMap(obj) {
 		var results = ret_obj.results, maps_key = ret_obj.maps_key;
 		img_data = results;
 
-		var text = "<img src=\"https://static-maps.yandex.ru/1.x/?lang=en-US&ll="+map_lng+','+map_lat+"&z="+map_zoom+"&l=map,skl&size="+width+","+height+"&pt=";
+		
+		var img_url = "https://naveropenapi.apigw.ntruss.com/map-static/v2/raster-cors?w="+width+"&amp;h="+height+"&amp;center="+map_lng+','+map_lat+"&amp;level="+map_zoom+"&amp;X-NCP-APIGW-API-KEY-ID="+encodeURIComponent(soo_map_api);
+		
 		var positions = map_marker_positions.split(";");
 		for(var i = 0; i < positions.length; i++)
 		{
+			if ( i == 0 ) {
+				img_url += "&amp;markers=type:d|size:mid|pos:"
+			}
 			if(!positions[i].trim()) continue;
 			i_position = positions[i].split(",");
-			text += i_position[1] + ',' + i_position[0] + ',vkgrm~-';
+			img_url += i_position[1] + encodeURIComponent(' ') + i_position[0] + encodeURIComponent(',');
 		}
-		text += "\" editor_component=\"map_components\" alt=\""+img_data+"\" style=\"border:2px dotted #FF0033; no-repeat center;width: "+width+"px; height: "+height+"px;\" />";
+		
+		var high_res_img = img_url + "&amp;scale=2";
+		
+		var text = "<img src=\"" + img_url + "\" srcset=\"" + img_url + ' 1x,' + high_res_img + " 2x\" editor_component=\"map_components\" alt=\""+img_data+"\" style=\"border:2px dotted #FF0033; no-repeat center;width: "+width+"px; height: "+height+"px;\" />";
 
 		opener.editorFocus(opener.editorPrevSrl);
 		var iframe_obj = opener.editorGetIFrame(opener.editorPrevSrl);


### PR DESCRIPTION
네이버 지도 API가 NBP 지도 API로 이관되면서, 변화가 생겼습니다. 이에 맞추어 업데이트 합니다.

NBP 지도 API는 무료 사용량이 없으며, 현재는 프로모션 기간으로 일정량의 무료 사용량을 프로모션으로 제공하고 있습니다. [참고](https://www.ncloud.com/product/applicationService/maps)